### PR TITLE
Handle Playwright navigation timeouts

### DIFF
--- a/server.py
+++ b/server.py
@@ -58,7 +58,13 @@ def _fetch_with_playwright(url: str) -> str:
         page = context.new_page()
         try:
             page.set_default_timeout(REQUEST_TIMEOUT_MS)
-            page.goto(url, wait_until="networkidle", timeout=REQUEST_TIMEOUT_MS)
+            page.goto(url, wait_until="domcontentloaded", timeout=REQUEST_TIMEOUT_MS)
+            try:
+                page.wait_for_load_state(
+                    "networkidle", timeout=max(REQUEST_TIMEOUT_MS // 2, 1)
+                )
+            except PlaywrightTimeoutError:
+                pass
             html_content = page.content()
         finally:
             context.close()

--- a/tests/test_server_fetch.py
+++ b/tests/test_server_fetch.py
@@ -42,3 +42,98 @@ def test_fetch_wraps_playwright_errors(monkeypatch):
         server.fetch("https://example.com")
 
     assert "Playwright failed to fetch" in str(exc.value)
+
+
+def test_playwright_timeout_fallback(monkeypatch):
+    import importlib
+
+    server = importlib.reload(importlib.import_module("server"))
+
+    class DummyTimeout(Exception):
+        pass
+
+    class DummyPage:
+        def __init__(self):
+            self.goto_calls = []
+            self.wait_calls = []
+            self.default_timeout = None
+
+        def set_default_timeout(self, value):
+            self.default_timeout = value
+
+        def goto(self, url, wait_until, timeout):
+            self.goto_calls.append((url, wait_until, timeout))
+
+        def wait_for_load_state(self, state, timeout):
+            self.wait_calls.append((state, timeout))
+            raise DummyTimeout("network idle never reached")
+
+        def content(self):
+            return "<html>ok</html>"
+
+    class DummyContext:
+        def __init__(self, page: DummyPage):
+            self.page = page
+            self.closed = False
+
+        def new_page(self):
+            return self.page
+
+        def close(self):
+            self.closed = True
+
+    class DummyBrowser:
+        def __init__(self, page: DummyPage):
+            self.page = page
+            self.headless = None
+            self.closed = False
+
+        def new_context(self, user_agent):
+            self.user_agent = user_agent
+            return DummyContext(self.page)
+
+        def close(self):
+            self.closed = True
+
+    class DummyChromium:
+        def __init__(self, page: DummyPage):
+            self.page = page
+
+        def launch(self, headless):
+            browser = DummyBrowser(self.page)
+            browser.headless = headless
+            return browser
+
+    class DummyPlaywright:
+        def __init__(self, page: DummyPage):
+            self.chromium = DummyChromium(page)
+
+    class DummyManager:
+        def __init__(self, page: DummyPage):
+            self.page = page
+
+        def __call__(self):
+            return self
+
+        def __enter__(self):
+            return DummyPlaywright(self.page)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    page = DummyPage()
+
+    manager = DummyManager(page)
+    monkeypatch.setattr(server, "sync_playwright", manager)
+    monkeypatch.setattr(server, "PlaywrightTimeoutError", DummyTimeout)
+
+    html = server._fetch_with_playwright("https://example.com")
+
+    assert html == "<html>ok</html>"
+    assert page.default_timeout == server.REQUEST_TIMEOUT_MS
+    assert page.goto_calls == [
+        ("https://example.com", "domcontentloaded", server.REQUEST_TIMEOUT_MS)
+    ]
+    assert page.wait_calls == [
+        ("networkidle", max(server.REQUEST_TIMEOUT_MS // 2, 1))
+    ]


### PR DESCRIPTION
## Summary
- relax the Playwright navigation wait to only require DOM content load and treat the network-idle wait as best-effort
- add unit coverage to ensure `_fetch_with_playwright` still returns markup when the network-idle wait times out

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb14b6ab648320b4cf8ac646280849