### PR TITLE
Handle HTML entity separators in price extraction

### DIFF
--- a/pricing_scrapper/scraper.py
+++ b/pricing_scrapper/scraper.py
@@ -43,6 +43,7 @@ def extract_prices(html_text: str, *, context: int = 60) -> List[PriceResult]:
     """Extract probable prices from raw HTML and provide textual context."""
 
     search_text = _SCRIPT_STYLE_RE.sub(" ", html_text)
+    search_text = html.unescape(search_text)
 
     results: List[PriceResult] = []
     seen: set[tuple[str, str]] = set()
@@ -72,6 +73,7 @@ def iter_prices(html_text: str) -> Iterable[str]:
     """Yield raw price strings from *html_text*."""
 
     search_text = _SCRIPT_STYLE_RE.sub(" ", html_text)
+    search_text = html.unescape(search_text)
 
     for match in PRICE_PATTERN.finditer(search_text):
         yield match.group().strip()


### PR DESCRIPTION
## Summary
- HTML-unescape the search text after removing script/style blocks to normalise entity whitespace before matching
- Extend scraper tests to cover &nbsp;/&#160;-separated prices across pattern, iterator, and extractors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc60b6ffcc83208b709e39604a8555