### PR TITLE
Add pagination-aware category scraping

### DIFF
--- a/pricing_scrapper/__init__.py
+++ b/pricing_scrapper/__init__.py
@@ -1,6 +1,6 @@
 """Pricing Scraper package."""
 
-from .knbk import Category, Product, parse_category_products
+from .knbk import Category, Product, parse_category_products, scrape_category_products
 
-__all__ = ["Category", "Product", "parse_category_products"]
+__all__ = ["Category", "Product", "parse_category_products", "scrape_category_products"]
 

--- a/tests/test_knbk_scraper.py
+++ b/tests/test_knbk_scraper.py
@@ -9,7 +9,12 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from pricing_scrapper.knbk import Category, Product, parse_category_products
+from pricing_scrapper.knbk import (
+    Category,
+    Product,
+    parse_category_products,
+    scrape_category_products,
+)
 
 
 def test_parse_category_products_extracts_all_groups():
@@ -113,4 +118,114 @@ def test_parse_category_products_generates_placeholder_when_missing_title():
     assert len(categories) == 1
     assert categories[0].name == "Category 1"
     assert categories[0].products == [Product(name="Test product", price="1 111 ₴", url="/p111")]
+
+
+def test_scrape_category_products_follows_pagination():
+    page_1 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Ручні кавомолки</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/p1">Кавомолка 1</a>
+              <span class="b-goods-price__value">100 ₴</span>
+            </div>
+          </div>
+        </section>
+        <nav class="pagination">
+          <a data-qaid="pagination_next" href="?page=2">Next</a>
+        </nav>
+      </body>
+    </html>
+    """
+
+    page_2 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Ручні кавомолки</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/p2">Кавомолка 2</a>
+              <span class="b-goods-price__value">200 ₴</span>
+            </div>
+          </div>
+        </section>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Аксесуари</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/a1">Щітка</a>
+              <span class="b-goods-price__value">50 ₴</span>
+            </div>
+          </div>
+        </section>
+        <nav class="pagination">
+          <a class="pager__next" href="?page=3"><span>›</span></a>
+        </nav>
+      </body>
+    </html>
+    """
+
+    page_3 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Аксесуари</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/a2">Колір</a>
+              <span class="b-goods-price__value">75 ₴</span>
+            </div>
+          </div>
+        </section>
+      </body>
+    </html>
+    """
+
+    pages = {
+        "https://example.com/cat/": page_1,
+        "https://example.com/cat/?page=2": page_2,
+        "https://example.com/cat/?page=3": page_3,
+    }
+
+    visited: list[str] = []
+
+    def fake_fetch(url: str) -> str:
+        visited.append(url)
+        return pages[url]
+
+    categories = scrape_category_products("https://example.com/cat/", fetch=fake_fetch)
+
+    assert visited == [
+        "https://example.com/cat/",
+        "https://example.com/cat/?page=2",
+        "https://example.com/cat/?page=3",
+    ]
+
+    assert categories == [
+        Category(
+            name="Ручні кавомолки",
+            products=[
+                Product(name="Кавомолка 1", price="100 ₴", url="/p1"),
+                Product(name="Кавомолка 2", price="200 ₴", url="/p2"),
+            ],
+        ),
+        Category(
+            name="Аксесуари",
+            products=[
+                Product(name="Щітка", price="50 ₴", url="/a1"),
+                Product(name="Колір", price="75 ₴", url="/a2"),
+            ],
+        ),
+    ]
 


### PR DESCRIPTION
## Summary
- detect pagination links on knbk category pages and walk through them when scraping
- expose a new `scrape_category_products` helper that aggregates products across pages
- cover pagination behaviour with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc70be2d108320a0411126911683c5