### PR TITLE
Preserve category path when following query pagination

### DIFF
--- a/pricing_scrapper/knbk.py
+++ b/pricing_scrapper/knbk.py
@@ -436,117 +436,91 @@ def _split_classes(value: str) -> Iterable[str]:
     return (part for part in re.split(r"\s+", value) if part)
 
 
-def _link_attrs_look_like_next(attrs: Dict[str, str]) -> bool:
-    href = attrs.get("href", "").strip()
-    if not href or href in {"#", "javascript:void(0)", "javascript:;", "void(0)"}:
-        return False
+_DATA_LINK_ATTRIBUTE_CANDIDATES = (
+    "data-url",
+    "data-href",
+    "data-link",
+    "data-next-url",
+    "data-next-href",
+    "data-target-url",
+    "data-page-url",
+    "data-page-link",
+)
+
+
+def _is_placeholder_href(value: str) -> bool:
+    normalized = value.strip()
+    if not normalized:
+        return True
+    lowered = normalized.casefold()
+    if lowered == "#":
+        return True
+    if lowered.startswith("javascript:"):
+        return True
+    if lowered in {"void(0)", "void(0);"}:
+        return True
+    return False
+
+
+def _extract_href_candidate(attrs: Dict[str, str]) -> Optional[str]:
+    href = attrs.get("href")
+    if href and not _is_placeholder_href(href):
+        return href.strip()
+
+    for key in _DATA_LINK_ATTRIBUTE_CANDIDATES:
+        candidate = attrs.get(key)
+        if candidate and not _is_placeholder_href(candidate):
+            stripped = candidate.strip()
+            if stripped:
+                return stripped
+
+    return None
+
+
+def _link_attrs_next_href(attrs: Dict[str, str]) -> Optional[str]:
+    href = _extract_href_candidate(attrs)
+    if not href:
+        return None
 
     rel = attrs.get("rel")
     if rel and any(part.casefold() == "next" for part in re.split(r"\s+", rel)):
-        return True
+        return href
 
     for key in ("data-qaid", "data-role", "data-action", "data-direction"):
         value = attrs.get(key)
         if value and any(keyword in value.casefold() for keyword in _NEXT_ATTR_KEYWORDS):
-            return True
+            return href
 
     aria_label = attrs.get("aria-label")
     if aria_label and _text_looks_like_next(aria_label):
-        return True
+        return href
 
     title = attrs.get("title")
     if title and _text_looks_like_next(title):
-        return True
+        return href
 
     classes = attrs.get("class")
     if classes:
         for cls in _split_classes(classes):
             lowered = cls.casefold()
             if lowered in _NEXT_CLASS_HINTS:
-                return True
+                return href
             if "next" in lowered and any(
-                hint in lowered for hint in ("pag", "pager", "page", "nav", "arrow")
+                hint in lowered for hint in ("pag", "pager", "page", "nav", "arrow", "btn")
             ):
-                return True
+                return href
 
-    return False
-
-
-class _PaginationParser(HTMLParser):
-    def __init__(self) -> None:
-        super().__init__()
-        self.next_href: Optional[str] = None
-        self._current_anchor: Optional[Dict[str, str]] = None
-        self._anchor_depth = 0
-        self._buffer: List[str] = []
-
-    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
-        if self.next_href is not None:
-            if tag == "a" and self._current_anchor is not None:
-                self._anchor_depth += 1
-            return
-
-        attrs_dict: Dict[str, str] = dict(attrs)
-
-        if tag == "link":
-            href = attrs_dict.get("href")
-            if href and _link_attrs_look_like_next(attrs_dict):
-                self.next_href = href
-            return
-
-        if tag != "a":
-            if self._current_anchor is not None:
-                self._anchor_depth += 1
-            return
-
-        href = attrs_dict.get("href")
-        if not href:
-            return
-
-        if _link_attrs_look_like_next(attrs_dict):
-            self.next_href = href
-            return
-
-        self._current_anchor = attrs_dict
-        self._buffer = []
-        self._anchor_depth = 0
-
-    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
-        if self._current_anchor is None:
-            return
-
-        if tag != "a":
-            if self._anchor_depth:
-                self._anchor_depth -= 1
-            return
-
-        if self._anchor_depth:
-            self._anchor_depth -= 1
-            return
-
-        href = self._current_anchor.get("href")
-        text = _normalize_text("".join(self._buffer))
-        if href and _text_looks_like_next(text):
-            self.next_href = href
-
-        self._current_anchor = None
-        self._buffer = []
-
-    def handle_data(self, data: str) -> None:  # type: ignore[override]
-        if self.next_href is not None:
-            return
-        if self._current_anchor is not None:
-            self._buffer.append(data)
+    return None
 
 
-def _find_next_page_url(html_text: str, base_url: str) -> Optional[str]:
-    parser = _PaginationParser()
-    parser.feed(html_text)
-    parser.close()
-
-    href = parser.next_href
+def _resolve_href(base_url: str, href: str) -> Optional[str]:
+    href = href.strip()
     if not href:
         return None
+
+    parsed_base = urlparse(base_url)
+    if href.startswith("?"):
+        return parsed_base._replace(query=href[1:], fragment="").geturl()
 
     joined = urljoin(base_url, href)
     if not joined:
@@ -561,6 +535,91 @@ def _find_next_page_url(html_text: str, base_url: str) -> Optional[str]:
         return None
 
     return parsed._replace(fragment="").geturl()
+
+
+class _PaginationParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.next_href: Optional[str] = None
+        self._current_candidate_tag: Optional[str] = None
+        self._current_candidate_href: Optional[str] = None
+        self._candidate_depth = 0
+        self._buffer: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        if self.next_href is not None:
+            return
+
+        attrs_dict: Dict[str, str] = dict(attrs)
+
+        if tag in {"link", "a", "button"}:
+            next_href = _link_attrs_next_href(attrs_dict)
+            if next_href:
+                self.next_href = next_href
+                self._reset_candidate()
+                return
+
+        if tag in {"a", "button"}:
+            href_candidate = _extract_href_candidate(attrs_dict)
+            if href_candidate:
+                self._current_candidate_tag = tag
+                self._current_candidate_href = href_candidate
+                self._buffer = []
+                self._candidate_depth = 0
+            elif self._current_candidate_tag is not None:
+                self._candidate_depth += 1
+            return
+
+        if self._current_candidate_tag is not None:
+            self._candidate_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
+        if self._current_candidate_tag is None:
+            return
+
+        if tag != self._current_candidate_tag:
+            if self._candidate_depth:
+                self._candidate_depth -= 1
+            return
+
+        if self._candidate_depth:
+            self._candidate_depth -= 1
+            return
+
+        href = self._current_candidate_href
+        text = _normalize_text("".join(self._buffer))
+        if href and _text_looks_like_next(text):
+            self.next_href = href
+
+        self._reset_candidate()
+
+    def handle_startendtag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        if self.next_href is not None:
+            return
+        if self._current_candidate_tag is not None:
+            self._buffer.append(data)
+
+    def _reset_candidate(self) -> None:
+        self._current_candidate_tag = None
+        self._current_candidate_href = None
+        self._candidate_depth = 0
+        self._buffer = []
+
+
+def _find_next_page_url(html_text: str, base_url: str) -> Optional[str]:
+    parser = _PaginationParser()
+    parser.feed(html_text)
+    parser.close()
+
+    href = parser.next_href
+    if not href:
+        return None
+
+    return _resolve_href(base_url, href)
 
 
 def scrape_category_products(

--- a/tests/test_knbk_scraper.py
+++ b/tests/test_knbk_scraper.py
@@ -229,3 +229,141 @@ def test_scrape_category_products_follows_pagination():
         ),
     ]
 
+
+def test_scrape_category_products_uses_data_url_when_href_placeholder():
+    page_1 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Турки</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/t1">Турка 1</a>
+              <span class="b-goods-price__value">300 ₴</span>
+            </div>
+          </div>
+        </section>
+        <nav class="pagination">
+          <a data-qaid="pagination_next" href="#" data-url="?page=2">Далі</a>
+        </nav>
+      </body>
+    </html>
+    """
+
+    page_2 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Турки</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/t2">Турка 2</a>
+              <span class="b-goods-price__value">350 ₴</span>
+            </div>
+          </div>
+        </section>
+      </body>
+    </html>
+    """
+
+    pages = {
+        "https://example.com/cat/": page_1,
+        "https://example.com/cat/?page=2": page_2,
+    }
+
+    visited: list[str] = []
+
+    def fake_fetch(url: str) -> str:
+        visited.append(url)
+        return pages[url]
+
+    categories = scrape_category_products("https://example.com/cat/", fetch=fake_fetch)
+
+    assert visited == [
+        "https://example.com/cat/",
+        "https://example.com/cat/?page=2",
+    ]
+
+    assert categories == [
+        Category(
+            name="Турки",
+            products=[
+                Product(name="Турка 1", price="300 ₴", url="/t1"),
+                Product(name="Турка 2", price="350 ₴", url="/t2"),
+            ],
+        )
+    ]
+
+
+def test_scrape_category_products_keeps_path_when_next_query_reference():
+    page_1 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Турки</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/t1">Турка 1</a>
+              <span class="b-goods-price__value">300 ₴</span>
+            </div>
+          </div>
+        </section>
+        <nav class="pagination">
+          <a data-qaid="pagination_next" href="?page=2">›</a>
+        </nav>
+      </body>
+    </html>
+    """
+
+    page_2 = """
+    <html>
+      <body>
+        <section class="b-products-group" data-qaid="catalog_group">
+          <div class="b-products-group__header">
+            <h2 class="b-products-group__title">Турки</h2>
+          </div>
+          <div class="b-products-group__body">
+            <div class="b-product-gallery__item" data-qaid="product_block">
+              <a class="b-product-gallery__title" href="/t2">Турка 2</a>
+              <span class="b-goods-price__value">350 ₴</span>
+            </div>
+          </div>
+        </section>
+      </body>
+    </html>
+    """
+
+    pages = {
+        "https://example.com/cat": page_1,
+        "https://example.com/cat?page=2": page_2,
+    }
+
+    visited: list[str] = []
+
+    def fake_fetch(url: str) -> str:
+        visited.append(url)
+        return pages[url]
+
+    categories = scrape_category_products("https://example.com/cat", fetch=fake_fetch)
+
+    assert visited == [
+        "https://example.com/cat",
+        "https://example.com/cat?page=2",
+    ]
+
+    assert categories == [
+        Category(
+            name="Турки",
+            products=[
+                Product(name="Турка 1", price="300 ₴", url="/t1"),
+                Product(name="Турка 2", price="350 ₴", url="/t2"),
+            ],
+        )
+    ]
+


### PR DESCRIPTION
## Summary
- accept pagination controls that expose the next URL via data-url/data-href attributes even when the href is a placeholder
- teach the pagination parser to work with anchor/button elements lacking a traditional href
- add a regression test covering pages where the next link stores the URL in a data attribute
- preserve the category path when the next-page reference is a bare query string so pagination keeps fetching the same catalog
- add a regression test ensuring '?page=' pagination links stay under the current category path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7b3315d4832087f2c8d3a6434fcb