### PR TITLE
Add hierarchical category scraping for knbk

### DIFF
--- a/pricing_scrapper/knbk.py
+++ b/pricing_scrapper/knbk.py
@@ -146,6 +146,44 @@ _EXCLUDED_PRICE_CLASS_KEYWORDS = (
 )
 
 
+_CATEGORY_LINK_CLASS_KEYWORDS = (
+    "catalog",
+    "categories",
+    "category",
+    "group",
+    "section",
+    "subcategory",
+    "collection",
+)
+
+_CATEGORY_LINK_DATA_QAID_KEYWORDS = (
+    "catalog",
+    "categories",
+    "category",
+    "group",
+    "section",
+    "subcategory",
+)
+
+_CATEGORY_LINK_EXCLUDED_CLASS_KEYWORDS = (
+    "breadcrumb",
+    "breadcrumbs",
+    "pagination",
+    "pager",
+    "footer",
+    "header",
+)
+
+_CATEGORY_LINK_EXCLUDED_DATA_QAID_KEYWORDS = (
+    "breadcrumb",
+    "breadcrumbs",
+    "pagination",
+    "pager",
+    "footer",
+    "header",
+)
+
+
 def _normalize_text(value: str) -> str:
     value = html.unescape(value)
     value = re.sub(r"\s+", " ", value)
@@ -224,6 +262,33 @@ def _is_product_price(element: _Element) -> bool:
         return True
     data_role = element.get("data-qaid", "").casefold()
     if "price" in data_role and "old" not in data_role:
+        return True
+    return False
+
+
+def _element_has_category_link_hint(element: _Element) -> bool:
+    if _class_matches(element, _CATEGORY_LINK_CLASS_KEYWORDS):
+        return True
+    if _dataqaid_matches(element, _CATEGORY_LINK_DATA_QAID_KEYWORDS):
+        return True
+    role = element.get("role")
+    if role and role.casefold() in {"list", "group", "listbox", "menu"}:
+        return True
+    data_role = element.get("data-role")
+    if data_role and any(
+        keyword in data_role.casefold() for keyword in _CATEGORY_LINK_DATA_QAID_KEYWORDS
+    ):
+        return True
+    return False
+
+
+def _element_in_category_link_excluded_region(element: _Element) -> bool:
+    if _class_matches(element, _CATEGORY_LINK_EXCLUDED_CLASS_KEYWORDS):
+        return True
+    if _dataqaid_matches(element, _CATEGORY_LINK_EXCLUDED_DATA_QAID_KEYWORDS):
+        return True
+    role = element.get("role")
+    if role and role.casefold() in {"navigation", "contentinfo"}:
         return True
     return False
 
@@ -610,6 +675,201 @@ def _find_next_page_url(html_text: str, base_url: str) -> Optional[str]:
     return parsed._replace(fragment="").geturl()
 
 
+def _path_looks_like_category(path: str) -> bool:
+    segments = [segment for segment in path.split("/") if segment]
+    if not segments:
+        return False
+    last = segments[-1]
+    lowered = last.casefold()
+    if len(lowered) < 2:
+        return False
+    if lowered[0] not in {"g", "c"}:
+        return False
+    digit_count = 0
+    for char in lowered[1:]:
+        if char.isdigit():
+            digit_count += 1
+            continue
+        break
+    return digit_count > 0
+
+
+def _normalize_catalog_url(
+    url: str, *, base_scheme: Optional[str] = None, base_netloc: Optional[str] = None
+) -> Optional[str]:
+    if not url:
+        return None
+    trimmed = url.strip()
+    if not trimmed:
+        return None
+
+    joined, _ = urldefrag(trimmed)
+    if not joined:
+        return None
+
+    parsed = urlparse(joined)
+    scheme = parsed.scheme or base_scheme or "https"
+    if scheme not in {"http", "https"}:
+        return None
+
+    netloc = parsed.netloc or base_netloc
+    if not netloc:
+        return None
+
+    if base_netloc and netloc.casefold() != base_netloc.casefold():
+        return None
+
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+        if not path:
+            path = "/"
+
+    normalized = parsed._replace(
+        scheme=scheme,
+        netloc=netloc,
+        path=path,
+        params="",
+        query="",
+        fragment="",
+    ).geturl()
+
+    return normalized
+
+
+@dataclass(slots=True)
+class _CategoryLink:
+    name: str
+    url: str
+
+
+class _CategoryLinkParser(HTMLParser):
+    def __init__(self, base_url: str) -> None:
+        super().__init__()
+        self._base_url = base_url
+        parsed = urlparse(base_url)
+        self._base_scheme = parsed.scheme or "https"
+        self._base_netloc = parsed.netloc
+        self._base_normalized = _normalize_catalog_url(
+            base_url, base_scheme=self._base_scheme, base_netloc=self._base_netloc
+        )
+
+        self.links: List[_CategoryLink] = []
+        self._stack: List[_Element] = []
+        self._current_href: Optional[str] = None
+        self._current_attrs: Optional[Dict[str, str]] = None
+        self._current_buffer: List[str] = []
+        self._current_depth = 0
+
+    # HTMLParser API -------------------------------------------------
+    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        element = _Element(tag=tag, attrs=dict(attrs))
+        self._stack.append(element)
+
+        if tag == "a":
+            href_candidate = _extract_href_candidate(element.attrs)
+            if not href_candidate:
+                return
+            absolute = urljoin(self._base_url, href_candidate)
+            normalized = _normalize_catalog_url(
+                absolute, base_scheme=self._base_scheme, base_netloc=self._base_netloc
+            )
+            if not normalized or normalized == self._base_normalized:
+                return
+
+            parsed = urlparse(normalized)
+            if not _path_looks_like_category(parsed.path):
+                return
+
+            if not self._anchor_has_category_hint():
+                return
+            if self._anchor_in_excluded_region():
+                return
+
+            self._current_href = normalized
+            self._current_attrs = element.attrs
+            self._current_buffer = []
+            self._current_depth = 0
+        elif self._current_href is not None:
+            self._current_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
+        if not self._stack:
+            return
+
+        element = self._stack.pop()
+
+        if self._current_href is None:
+            return
+
+        if tag == "a":
+            if self._current_depth:
+                self._current_depth -= 1
+                return
+
+            name = _normalize_text("".join(self._current_buffer))
+            if not name and self._current_attrs:
+                for key in ("title", "aria-label", "data-name"):
+                    value = self._current_attrs.get(key)
+                    if value:
+                        candidate = _normalize_text(value)
+                        if candidate:
+                            name = candidate
+                            break
+            if not name:
+                parsed_href = urlparse(self._current_href)
+                name = parsed_href.path or self._current_href
+
+            if name:
+                self.links.append(_CategoryLink(name=name, url=self._current_href))
+
+            self._reset_current()
+        elif self._current_depth:
+            self._current_depth -= 1
+
+    def handle_startendtag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        if self._current_href is not None and data:
+            self._current_buffer.append(data)
+
+    # Helpers --------------------------------------------------------
+    def _anchor_has_category_hint(self) -> bool:
+        for element in reversed(self._stack):
+            if _element_has_category_link_hint(element):
+                return True
+        return False
+
+    def _anchor_in_excluded_region(self) -> bool:
+        for element in reversed(self._stack):
+            if _element_in_category_link_excluded_region(element):
+                return True
+        return False
+
+    def _reset_current(self) -> None:
+        self._current_href = None
+        self._current_attrs = None
+        self._current_buffer = []
+        self._current_depth = 0
+
+
+def _parse_subcategory_links(html_text: str, base_url: str) -> List[_CategoryLink]:
+    parser = _CategoryLinkParser(base_url)
+    parser.feed(html_text)
+    parser.close()
+
+    seen: set[str] = set()
+    ordered: List[_CategoryLink] = []
+    for link in parser.links:
+        if link.url in seen:
+            continue
+        seen.add(link.url)
+        ordered.append(link)
+    return ordered
+
+
 def scrape_category_products(
     url: str, *, fetch: Callable[[str], str]
 ) -> List[Category]:
@@ -648,4 +908,38 @@ def scrape_category_products(
             break
 
     return [aggregated[key] for key in ordered_keys]
+
+
+def scrape_category_hierarchy_products(
+    url: str, *, fetch: Callable[[str], str]
+) -> List[Category]:
+    """Recursively scrape *url* and nested subcategories collecting all products."""
+
+    results: List[Category] = []
+    visited: set[str] = set()
+
+    def walk(current_url: str, path: tuple[str, ...]) -> None:
+        normalized = _normalize_catalog_url(current_url)
+        if not normalized or normalized in visited:
+            return
+        visited.add(normalized)
+
+        html_text = fetch(current_url)
+
+        page_categories = scrape_category_products(current_url, fetch=fetch)
+        for category in page_categories:
+            path_parts = list(path)
+            if not path_parts or path_parts[-1] != category.name:
+                path_parts.append(category.name)
+            full_name = " / ".join(part for part in path_parts if part)
+            results.append(
+                Category(name=full_name, products=list(category.products))
+            )
+
+        sub_links = _parse_subcategory_links(html_text, current_url)
+        for link in sub_links:
+            walk(link.url, path + (link.name,))
+
+    walk(url, tuple())
+    return results
 


### PR DESCRIPTION
## Summary
- add robust parsing for nested category links on knbk catalog pages
- expose `scrape_category_hierarchy_products` to recursively collect products across a hierarchy
- extend test coverage with a synthetic multi-level catalog scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9b79f5a88320a54aabb259190528